### PR TITLE
Migration upgrade

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,5 +1,6 @@
 DATABASE_CONNECTION_POOLSIZE=20
 DATABASE_CONNECTION_OVERFLOWPOOL=20
 DATABASE_CONNECTION_POOLRECYCLE=3600
-DATABASE_CONNECTION_DEBUG=False
-DB_ENGINE_URL=mysql+pymysql://root:@database/starfinder_development?charset=utf8
+DATABASE_CONNECTION_DEBUG=True
+DB_ENGINE_URL=mysql+pymysql://root:@127.0.0.1:3306/starfinder_development?charset=utf8
+ENVIRONMENT=development

--- a/Makefile
+++ b/Makefile
@@ -12,15 +12,29 @@ run :  ## docker compose everything
 	@echo "environment: ${ENVIRONMENT}"
 	@$(SUDO) chown -R $$USER:$(PRIMARY_GROUP) ./database_data; \
 	$(DOCKER_COMPOSE) docker-compose.${ENVIRONMENT}.yml up -d
-	$(DB_URL) starfinder_db_manage create_database
+	$(DB_URL) $(BASENAME)_db_manage create_database
 
 .PHONY : stop
 stop : ## teardown compose containers
 	@$(DOCKER_COMPOSE) docker-compose.${ENVIRONMENT}.yml stop; \
 	$(DOCKER_COMPOSE) docker-compose.${ENVIRONMENT}.yml rm -f
 
+.PHONY : running_web
+running_web :
+	@if [ "$(shell ${COMPOSE_CHECK} web | egrep -q "web.*Up" && echo 1 || echo 0)" -eq 0 ]; \
+	then \
+		echo "No running web found. Please start it with 'make run'"; \
+	fi
+
+.PHONY : running_database
+running_database :
+	@if [ "$(shell ${COMPOSE_CHECK} database | egrep -q "database.*Up" && echo 1 || echo 0)" -eq 0 ]; \
+	then \
+		echo "No running database found. Please start it with 'make run'"; \
+	fi
+
 .PHONY : reset_web
-reset_web : ## teardown and recreate web container
+reset_web : running_web ## teardown and recreate web container
 	@$(DOCKER) stop $(BASENAME)_web_1; \
 	$(DOCKER) rm $(BASENAME)_web_1; \
 	$(DOCKER_COMPOSE) docker-compose.${ENVIRONMENT}.yml up -d
@@ -29,6 +43,10 @@ reset_web : ## teardown and recreate web container
 logs : ## show logs from the last 10 minutes
 	@echo Starting logs for $(BASENAME) ${ENVIRONMENT}...
 	$(DOCKER) logs -f $(BASENAME)_web_1 --since 10m
+
+.PHONY : db_cli
+db_cli : running_database ## go to database CLI
+	@$(DOCKER_COMPOSE) docker-compose.${ENVIRONMENT}.yml exec database mysql -uroot --database $(BASENAME)_${ENVIRONMENT}
 
 .PHONY : db_localhost
 db_localhost : ## change database to 127.0.0.1:3306 in .env

--- a/starfinder/db/migrations/cli.py
+++ b/starfinder/db/migrations/cli.py
@@ -34,6 +34,20 @@ def create_database():
         sqlalchemy_utils.create_database(ENGINE_URL)
 
 
+def abort_if_false(ctx, _param, value):
+    if not value:
+        ctx.abort()
+
+
+@migrate_cli.command(help="Drops the database if it exists")
+@click.option('--confirm', is_flag=True, callback=abort_if_false,
+              expose_value=False,
+              prompt='Are you sure you want to drop the database?')
+def drop_database():
+    if sqlalchemy_utils.database_exists(models.engine.url):
+        sqlalchemy_utils.drop_database(models.engine.url)
+
+
 def test_connection():
     if not models.can_connect():
         print("Couldn't connect to the database. Your engine URL is:")

--- a/starfinder/db/migrations/cli.py
+++ b/starfinder/db/migrations/cli.py
@@ -52,7 +52,6 @@ def _dispatch_alembic_cmd(config, cmd, *args, **kwargs):
 def _get_head_path(script):
     if len(script.get_heads()) > 1:
         alembic_util.err('Timeline branches unable to generate timeline')
-
     head_path = os.path.join(script.versions, HEAD_FILENAME)
     return head_path
 
@@ -71,6 +70,21 @@ def revision(ctx, message):
     config = ctx.obj["alembic_config"]
     _dispatch_alembic_cmd(config, "revision", message=message)
     _update_head_file(config)
+
+
+@migrate_cli.command(help="Upgrades the database to the specified version. "
+                          "Pass 'head' as the revision to upgrade to the latest "
+                          "version")
+@click.pass_context
+@click.argument("migration_revision")
+def upgrade(ctx, migration_revision):
+    test_connection()
+    config = ctx.obj["alembic_config"]
+    if not sqlalchemy_utils.database_exists(ENGINE_URL):
+        alembic_util.err("Cannot continue. The database must be created with "
+                         "'create_database' first")
+    migration_revision = migration_revision.lower()
+    _dispatch_alembic_cmd(config, "upgrade", revision=migration_revision)
 
 
 def main():

--- a/starfinder/db/models.py
+++ b/starfinder/db/models.py
@@ -1,7 +1,8 @@
 import contextlib
 
 import sqlalchemy as sa
-from sqlalchemy import orm
+from sqlalchemy import orm, func
+from sqlalchemy.ext import declarative
 
 from starfinder import config, logging
 
@@ -9,15 +10,14 @@ CONF = config.CONF
 LOG = logging.get_logger(__name__)
 DB_NAME = "starfinder_{}".format(CONF.get("ENVIRONMENT"))
 ENGINE_URL = CONF.get("DB_ENGINE_URL")
+TABLE_KWARGS = {"mysql_engine": "InnoDB",
+                "mysql_charset": "utf8",
+                "mysql_collate": "utf8_general_ci"}
 
 connection_debug = CONF.get("database.connection.debug")
 connection_debug = connection_debug.lower() == "true"
 connection_pool_size = int(CONF.get("database.connection.poolsize"))
 connection_overflow_pool = int(CONF.get("database.connection.overflowpool"))
-# NOTE: MySQL defaults to 8 hour connection timeouts. It's possible that
-#      docker-compose or our hosting provider will sever connections sooner.
-#      if we see "MySQL has gone away" tweaking this variable is the thing
-#      to revisit
 connection_pool_recycle = int(CONF.get("database.connection.poolrecycle"))
 
 engine_kwargs = {}
@@ -59,3 +59,93 @@ def transaction():
         LOG.exception("Transaction failed! Rolling back...")
         session.rollback()
         raise
+
+class MetaBase(declarative.DeclarativeMeta):
+    def __init__(cls, klsname, bases, attrs):
+        if klsname != "Base":
+            super().__init__(klsname, bases, attrs)
+            for attr_name, attr in attrs.items():
+                if isinstance(attr, sa.Column):
+                    query_single_getter_name = "get_by_{}".format(attr_name)
+                    query_all_getter_name = "get_all_by_{}".format(attr_name)
+                    if not hasattr(cls, query_single_getter_name):
+                        setattr(cls, query_single_getter_name,
+                                functools.partial(cls._get_by, attr))
+
+                    if not hasattr(cls, query_all_getter_name):
+                        setattr(cls, query_all_getter_name,
+                                functools.partial(cls._get_all_by, attr))
+
+
+class ModelBase(object):
+    created_at = sa.Column(sa.DateTime(), server_default=func.now())
+    updated_at = sa.Column(sa.DateTime(), onupdate=func.now())
+    __table_args__ = TABLE_KWARGS
+
+    @declarative.declared_attr
+    def __tablename__(cls):
+        """ Returns a snake_case form of the table name. """
+        return db_utils.pluralize(db_utils.to_snake_case(cls.__name__))
+
+    def __eq__(self, other):
+        if not other:
+            return False
+        return self.id == other.id
+
+    def __getitem__(self, key):
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
+
+    def __setitem__(self, key, value):
+        if hasattr(self, key):
+            return setattr(self, key, value)
+        raise AttributeError(key)
+
+    def __contains__(self, key):
+        return hasattr(self, key)
+
+    def update(self, **fields):
+        for attr, value in fields.items():
+            if attr not in self:
+                raise exception.ModelUnknownAttrbute(model=self, attr=attr)
+            self[attr] = value
+        return self
+
+    @classmethod
+    def get(cls, pk):
+        return Session.query(cls).filter(cls.id == pk).first()
+
+    @classmethod
+    def _get_by_property(cls, prop):
+        LOG.debug("Fetching '%s' by property '%s'", cls, prop)
+        return Session.query(cls).filter(prop).first()
+
+    @classmethod
+    def _get_by(cls, field, value):
+        LOG.debug("Fetching one '%s.%s' by value '%s'", cls, field, value)
+        return Session.query(cls).filter(field == value).first()
+
+    @classmethod
+    def _get_all_by(cls, field, value):
+        LOG.debug("Fetching all '%s.%s' with value '%s'", cls, field, value)
+        return Session.query(cls).filter(field == value).all()
+
+    def save(self):
+        LOG.debug("Attempting to save '%s'", self)
+        with transaction() as session:
+            session.add(self)
+
+    def delete(self):
+        LOG.debug("Attempting to delete '%s'", self)
+        with transaction() as session:
+            session.delete(self)
+
+    def to_dict(self):
+        return {key: value for key, value in self.__dict__.items()
+                if not callable(value) and not key.startswith('_')}
+
+
+Base = declarative.declarative_base(cls=ModelBase, bind=engine,
+                                    metaclass=MetaBase)


### PR DESCRIPTION
Database now runs with `make database`, but _not_ on `make run`... that was being wonky, so I skipped it for now.

Migrations and Upgrades are now fully functional!